### PR TITLE
Feat/active selected component

### DIFF
--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import Konva from 'konva';
 import { Stage, Layer } from 'react-konva';
 
+import { STROKE_COLOR_HOVER } from 'figura/config/constants';
 import { useDrawer } from 'figura/hooks/useDrawer';
 import { Figure } from '../Figure';
 
@@ -13,8 +14,8 @@ type PrimitiveProps = Omit<ComponentProps<'div'>, 'children'>;
 interface DrawerProps extends PrimitiveProps {}
 
 const Drawer: FC<DrawerProps> = ({ ref, className, ...props }) => {
-  const { state, isSelecting, hoverSelection, handler, handleHoverSelection } = useDrawer();
-  const { figures } = state;
+  const { state, hoverSelection, handler, handleHoverSelection } = useDrawer();
+  const { figures, isSelecting } = state;
   const { mouseDown, mouseUp } = handler;
   const currentFigures = figures;
 
@@ -44,14 +45,14 @@ const Drawer: FC<DrawerProps> = ({ ref, className, ...props }) => {
       >
         <Layer>
           {(currentFigures ?? []).map(({ id, type, props }) => (
-            <Figure key={id} type={type} props={props} />
+            <Figure key={id} id={id} type={type} props={props} />
           ))}
           {isSelecting && (
             <Figure
               type="Rect"
               props={{
                 ...hoverSelection,
-                stroke: '#09f',
+                stroke: STROKE_COLOR_HOVER,
                 strokeWidth: 1,
               }}
             />

--- a/src/components/Figure/Figure.tsx
+++ b/src/components/Figure/Figure.tsx
@@ -1,9 +1,19 @@
-import { type FC, memo } from 'react';
+import { type FC, memo, useState } from 'react';
+import Konva from 'konva';
 import { Text, Rect, Circle } from 'react-konva';
 
-import type { Child, PrimitiveFigure } from 'figura/models/idrawer';
+import { Child, DrawerType, PrimitiveFigure } from 'figura/models/idrawer';
+import { useDrawer } from 'figura/hooks/useDrawer';
+import {
+  MAX_RECT_SIZE_SELECTED,
+  SELECTION_OF_FIGURE_PROPERTIES,
+  STROKE_COLOR_HOVER,
+  STROKE_WIDTH_HOVER,
+} from 'figura/config/constants';
 
-interface FigureProps extends Child {}
+interface FigureProps extends Child {
+  id?: string;
+}
 
 const Element: Record<Child['type'], PrimitiveFigure> = {
   Rect,
@@ -11,10 +21,59 @@ const Element: Record<Child['type'], PrimitiveFigure> = {
   Text,
 };
 
-const Figure: FC<FigureProps> = ({ type, props }) => {
+const Figure: FC<FigureProps> = ({ id, type, props }) => {
   const Figura = Element[type];
+  const { state, dispatch } = useDrawer();
+  const [hovered, setHovered] = useState(false);
+  const { isSelecting, selectedId } = state;
+  const selected = selectedId === id;
 
-  return <Figura {...props} />;
+  const hoverPositionX = props.x - MAX_RECT_SIZE_SELECTED / 2;
+  const hoverPositionY = props.y - MAX_RECT_SIZE_SELECTED / 2;
+  const xHover = props.x + props.width - MAX_RECT_SIZE_SELECTED / 2;
+  const yHover = props.y + props.height - MAX_RECT_SIZE_SELECTED / 2;
+
+  const handleClick = (event: Konva.KonvaEventObject<MouseEvent>) => {
+    dispatch({ type: DrawerType.FIGURE_SELECTED, payload: id });
+    props.onClick?.(event);
+  };
+
+  const handleMouseMove = (event: Konva.KonvaEventObject<MouseEvent>) => {
+    if (!hovered && !isSelecting) {
+      setHovered(true);
+    }
+
+    props.onMouseMove?.(event);
+  };
+
+  const handleMouseLeave = (event: Konva.KonvaEventObject<MouseEvent>) => {
+    if (hovered) {
+      setHovered(false);
+    }
+
+    props.onMouseLeave?.(event);
+  };
+
+  return (
+    <>
+      <Figura
+        {...props}
+        onClick={handleClick}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+        stroke={hovered || selected ? STROKE_COLOR_HOVER : props.stroke}
+        strokeWidth={hovered ? STROKE_WIDTH_HOVER : props.strokeWidth}
+      />
+      {selected && (
+        <>
+          <Rect x={hoverPositionX} y={hoverPositionY} {...SELECTION_OF_FIGURE_PROPERTIES} />
+          <Rect x={xHover} y={hoverPositionY} {...SELECTION_OF_FIGURE_PROPERTIES} />
+          <Rect x={xHover} y={yHover} {...SELECTION_OF_FIGURE_PROPERTIES} />
+          <Rect x={hoverPositionX} y={yHover} {...SELECTION_OF_FIGURE_PROPERTIES} />
+        </>
+      )}
+    </>
+  );
 };
 
 export default memo(Figure);

--- a/src/config/constants/drawer.constants.ts
+++ b/src/config/constants/drawer.constants.ts
@@ -3,6 +3,8 @@ import type { DrawerState, HoverSelection, IPosition } from 'figura/models';
 export const INITIALDRAWER_CONTEXT_STATE: DrawerState = {
   action: 'selection',
   figures: [],
+  isSelecting: false,
+  selectedId: null,
 };
 
 export const INITIAL_POSITIONS: IPosition = {
@@ -17,4 +19,18 @@ export const DEFAULT_HOVER_SELECTION: HoverSelection = {
   initY: 0,
   width: 0,
   height: 0,
+};
+
+export const STROKE_WIDTH_HOVER = 3;
+
+export const STROKE_COLOR_HOVER = '#09f';
+
+export const MAX_RECT_SIZE_SELECTED = 10;
+
+export const SELECTION_OF_FIGURE_PROPERTIES = {
+  width: MAX_RECT_SIZE_SELECTED,
+  height: MAX_RECT_SIZE_SELECTED,
+  fill: '#ddd',
+  stroke: STROKE_COLOR_HOVER,
+  strokeWidth: 1,
 };

--- a/src/contexts/DrawerProvider/DrawerContext.ts
+++ b/src/contexts/DrawerProvider/DrawerContext.ts
@@ -6,7 +6,6 @@ import { INITIALDRAWER_CONTEXT_STATE } from 'figura/config/constants';
 
 export const DrawerContext = createContext<DrawerContextType>({
   state: INITIALDRAWER_CONTEXT_STATE,
-  isSelecting: false,
   hoverSelection: { initX: 0, initY: 0, x: 0, y: 0, width: 0, height: 0 },
   handler: {
     mouseDown: noop,

--- a/src/contexts/DrawerProvider/reducer.ts
+++ b/src/contexts/DrawerProvider/reducer.ts
@@ -19,6 +19,10 @@ export default function reducer(
         figures: structuredClone([...state.figures, newFigure]),
       };
     }
+    case DrawerType.HOVER_SELECTION:
+      return { ...state, isSelecting: payload };
+    case DrawerType.FIGURE_SELECTED:
+      return { ...state, selectedId: payload };
     case DrawerType.CHANGE_DRAW_ACTION:
       return { ...state, action: payload };
     default:

--- a/src/contexts/ListenerProvider/ListenerProvider.tsx
+++ b/src/contexts/ListenerProvider/ListenerProvider.tsx
@@ -11,17 +11,18 @@ function ListenerProvider({ children }: PropsWithChildren) {
   const [keyPressed, setkeyPressed] = useState<Set<string>>(new Set());
 
   const listeners = (event: KeyboardEvent) => {
+    let newKeyPress = new Set<string>();
+
     setkeyPressed((prevKeyPress) => {
-      const newKeyPress = new Set(prevKeyPress).add(event.key);
-
-      Object.entries(COMMANDS).forEach(([command, keys]) => {
-        if (keys.every((key) => newKeyPress.has(key))) {
-          event.preventDefault();
-          observable.notify(command as ICommandName);
-        }
-      });
-
+      newKeyPress = new Set(prevKeyPress).add(event.key);
       return newKeyPress;
+    });
+
+    Object.entries(COMMANDS).forEach(([command, keys]) => {
+      if (keys.every((key) => newKeyPress.has(key))) {
+        event.preventDefault();
+        observable.notify(command as ICommandName);
+      }
     });
   };
 

--- a/src/models/idrawer.ts
+++ b/src/models/idrawer.ts
@@ -5,6 +5,8 @@ import { type KonvaNodeComponent } from 'react-konva';
 export enum DrawerType {
   NEW_FIGURE,
   CHANGE_DRAW_ACTION,
+  HOVER_SELECTION,
+  FIGURE_SELECTED,
 }
 
 export type PrimitiveFigure =
@@ -27,6 +29,8 @@ export interface Figure extends Child {
 export interface DrawerState {
   action: DrawAction;
   figures: Figure[];
+  isSelecting: boolean;
+  selectedId: string | null;
 }
 
 type Handler = (event: Konva.KonvaEventObject<MouseEvent>) => void;
@@ -42,7 +46,6 @@ export interface HoverSelection {
 
 export interface DrawerContextType {
   state: DrawerState;
-  isSelecting: boolean;
   hoverSelection: HoverSelection;
   handler: {
     mouseDown: Handler;


### PR DESCRIPTION
# Issues

Closes #4 

## Features / Fix

- [X] Fix bug to try change setState while DrawerProvider trying make a rerender using listener hook from a ListenerProvider for detect command
- [X] selection figure created
- [X] deselection figure implemented using previous feature [listener detection commands](https://github.com/Juanestban/figura/pull/7)

## screenshots

### selected figure
![image](https://github.com/user-attachments/assets/dd780f51-1eba-4898-9470-212fb04677fc)

### selected + hovered figure
![image](https://github.com/user-attachments/assets/e8d71f9f-1d14-4c8e-8e5d-774d9c082105)
